### PR TITLE
get_corpus_metadata No Longer Iterates Through All Docs

### DIFF
--- a/gender_analysis/corpus.py
+++ b/gender_analysis/corpus.py
@@ -288,10 +288,7 @@ class Corpus(common.FileLoaderMixin):
 
         :return: list
         """
-        metadata_fields = set()
-        for document in self.documents:
-            for field in document.members:
-                metadata_fields.add(field)
+        metadata_fields = self.documents[0].members
         return sorted(list(metadata_fields))
 
     def get_field_vals(self, field):


### PR DESCRIPTION
`get_corpus_metadata` now retrieves a list of metadata from only the first document rather than iterating through the entire corpus.