### PR TITLE
corpus.get_corpus_metadata() replaced with corpus.metadata_fields

### DIFF
--- a/gender_analysis/analysis/corpus_metadata_visualizations.py
+++ b/gender_analysis/analysis/corpus_metadata_visualizations.py
@@ -14,7 +14,7 @@ def plot_pubyears(corpus, filename=None):
     :param filename: str to name plot file
     RETURNS a pyplot histogram
     """
-    if 'date' not in corpus.get_corpus_metadata():
+    if 'date' not in corpus.metadata_fields:
         raise MissingMetadataError("This corpus does not contain metadata field 'date'.")
 
     pub_years = []
@@ -58,7 +58,7 @@ def plot_pubcountries(corpus, filename=None):
     :param filename: str to name plot file
     RETURNS a pyplot bargraph
     """
-    if 'country_publication' not in corpus.get_corpus_metadata():
+    if 'country_publication' not in corpus.metadata_fields:
         raise MissingMetadataError("This corpus does not contain metadata field "
                                    "'country_publication'.")
 
@@ -120,7 +120,7 @@ def plot_gender_breakdown(corpus, filename=None):
     :param filename: str to name plot file
     RETURNS a pie chart
     """
-    if 'author_gender' not in corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields:
         raise MissingMetadataError("This corpus does not contain metadata field 'author_gender'.")
 
     pub_gender = []
@@ -169,8 +169,8 @@ def plot_metadata_pie(corpus, filename=None):
     :param corpus: Corpus
     :param filename: str to name plot file
     """
-    if 'author_gender' not in corpus.get_corpus_metadata() or 'country_publication' not in \
-            corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields or 'country_publication' not in \
+            corpus.metadata_fields:
         raise MissingMetadataError("This corpus does not contain metadata fields 'author_gender' "
                                    "or 'publication_country'.")
 

--- a/gender_analysis/analysis/dunning.py
+++ b/gender_analysis/analysis/dunning.py
@@ -164,7 +164,7 @@ def male_vs_female_authors_analysis_dunning_lesser(corpus):
     tests word distinctiveness of shared words between male and female corpora using dunning
     :return: dictionary of common shared words and their distinctiveness
     """
-    if 'author_gender' not in corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields:
         raise MissingMetadataError("Corpus does not contain metadata field 'author_gender'.")
 
     m_corpus = corpus.filter_by_gender('male')
@@ -343,7 +343,7 @@ def male_vs_female_analysis_dunning(corpus, display_data=False, to_pickle=False)
 
     :return: dict
     """
-    if 'author_gender' not in corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields:
         raise MissingMetadataError("Corpus does not contain metadata field 'author_gender'.")
 
     # By default, try to load precomputed results. Only calculate if no stored results are
@@ -439,7 +439,7 @@ def male_vs_female_authors_analysis_dunning(corpus, display_results=False, to_pi
 
     :return:dict
     """
-    if 'author_gender' not in corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields:
         raise MissingMetadataError("Corpus does not contain metadata field 'author_gender'.")
 
     # By default, try to load precomputed results. Only calculate if no stored results are
@@ -513,7 +513,7 @@ def female_characters_author_gender_differences(corpus, to_pickle=False):
     :param to_pickle
     :return:
     """
-    if 'author_gender' not in corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields:
         raise MissingMetadataError("Corpus does not contain metadata field 'author_gender'.")
 
     male_corpus = corpus.filter_by_gender('male')
@@ -535,7 +535,7 @@ def male_characters_author_gender_differences(corpus, to_pickle=False):
     :param to_pickle
     :return:
     """
-    if 'author_gender' not in corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields:
         raise MissingMetadataError("Corpus does not contain metadata field 'author_gender'.")
 
     male_corpus = corpus.filter_by_gender('male')
@@ -557,7 +557,7 @@ def god_author_gender_differences(corpus, to_pickle=False):
     :param to_pickle
     :return:
     """
-    if 'author_gender' not in corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields:
         raise MissingMetadataError("Corpus does not contain metadata field 'author_gender'.")
 
     male_corpus = corpus.filter_by_gender('male')
@@ -576,7 +576,7 @@ def money_author_gender_differences(corpus, to_pickle=False):
     :param to_pickle
     :return:
     """
-    if 'author_gender' not in corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields:
         raise MissingMetadataError("Corpus does not contain metadata field 'author_gender'.")
 
     male_corpus = corpus.filter_by_gender('male')
@@ -601,7 +601,7 @@ def america_author_gender_differences(corpus, to_pickle=False):
     :param to_pickle
     :return:
     """
-    if 'author_gender' not in corpus.get_corpus_metadata():
+    if 'author_gender' not in corpus.metadata_fields:
         raise MissingMetadataError("Corpus does not contain metadata field 'author_gender'.")
 
     male_corpus = corpus.filter_by_gender('male')

--- a/gender_analysis/corpus.py
+++ b/gender_analysis/corpus.py
@@ -44,12 +44,15 @@ class Corpus(common.FileLoaderMixin):
         self.csv_path = csv_path
         self.path_to_files = path_to_files
         self.documents = []
+        self._metadata_fields = []
 
         if self.path_to_files.suffix == '.pgz':
             pickle_data = common.load_pickle(self.path_to_files)
             self.documents = pickle_data.documents
+            self.metadata_fields = pickle_data.metadata
         elif self.path_to_files.suffix == '' and not self.csv_path:
             files = listdir(self.path_to_files)
+            self._metadata_fields = ['filename', 'filepath']
             for file in files:
                 if file.endswith('.txt'):
                     metadata_dict = {'filename': file, 'filepath': self.path_to_files / file}
@@ -58,6 +61,10 @@ class Corpus(common.FileLoaderMixin):
             self.documents = self._load_documents()
         else:
             raise ValueError(f'path_to_files must lead to a a previously pickled corpus or directory of .txt files')
+
+    @property
+    def metadata_fields(self):
+        return self._metadata_fields
 
     def __len__(self):
         """
@@ -181,6 +188,7 @@ class Corpus(common.FileLoaderMixin):
 
     def _load_documents(self):
         documents = []
+        metadata = set()
 
         try:
             csv_file = self.load_file(self.csv_path)
@@ -196,7 +204,9 @@ class Corpus(common.FileLoaderMixin):
             document_metadata['filepath'] = self.path_to_files / document_metadata['filename']
             this_document = Document(document_metadata)
             documents.append(this_document)
+            metadata.update(list(document_metadata))
 
+        self._metadata_fields = list(metadata)
         return sorted(documents)
 
     def count_authors_by_gender(self, gender):
@@ -273,23 +283,6 @@ class Corpus(common.FileLoaderMixin):
             corpus_counter += document_counter
         return corpus_counter
 
-    def get_corpus_metadata(self):
-        """
-        This function returns a sorted list of all metadata fields
-        in the corpus as strings. This is different from the get_metadata_fields;
-        this returns the fields which are specific to the corpus it is being called on.
-        >>> from gender_analysis.corpus import Corpus
-        >>> from gender_analysis.common import BASE_PATH
-        >>> path = BASE_PATH / 'testing' / 'corpora' / 'sample_novels' / 'texts'
-        >>> c = Corpus(path)
-        >>> c.get_corpus_metadata()
-        ['filename', 'filepath']
-
-        :return: list
-        """
-        metadata_fields = self.documents[0].members
-        return sorted(list(metadata_fields))
-
     def get_field_vals(self, field):
         """
         This function returns a sorted list of all values for a
@@ -306,9 +299,8 @@ class Corpus(common.FileLoaderMixin):
         :param field: str
         :return: list
         """
-        metadata_fields = self.get_corpus_metadata()
 
-        if field not in metadata_fields:
+        if field not in self.metadata_fields:
             raise ValueError(
                 f'\'{field}\' is not a valid metadata field for this corpus'
             )
@@ -367,12 +359,10 @@ class Corpus(common.FileLoaderMixin):
         :param field_value: str
         :return: Corpus
         """
-
-        supported_metadata_fields = self.get_corpus_metadata()
         
-        if metadata_field not in supported_metadata_fields:
+        if metadata_field not in self.metadata_fields:
             raise ValueError(
-                f'Metadata field must be {", ".join(supported_metadata_fields)} '
+                f'Metadata field must be {", ".join(self.metadata_fields)} '
                 + f'but not {metadata_field}.')
 
         corpus_copy = self.clone()
@@ -422,15 +412,14 @@ class Corpus(common.FileLoaderMixin):
         >>> len(c.multi_filter(corpus_filter))
         1
         """
-        supported_metadata_fields = self.get_corpus_metadata()
 
         corpus_copy = self.clone()
         corpus_copy.documents = []
 
         for metadata_field in characteristic_dict:
-            if metadata_field not in supported_metadata_fields:
+            if metadata_field not in self.metadata_fields:
                 raise ValueError(
-                    f'Metadata field must be {", ".join(supported_metadata_fields)} '
+                    f'Metadata field must be {", ".join(self.metadata_fields)} '
                     + f'but not {metadata_field}.')
 
         for this_document in self.documents:
@@ -482,7 +471,7 @@ class Corpus(common.FileLoaderMixin):
         :return: Document
         """
 
-        if metadata_field not in self.get_corpus_metadata():
+        if metadata_field not in self.metadata_fields:
             raise AttributeError(f"Metadata field {metadata_field} invalid for this corpus")
 
         if metadata_field == "date":
@@ -563,7 +552,7 @@ class Corpus(common.FileLoaderMixin):
         """
 
         for field in metadata_dict.keys():
-            if field not in self.get_corpus_metadata():
+            if field not in self.metadata_fields:
                 raise AttributeError(f"Metadata field {field} invalid for this corpus")
 
         for document in self.documents:

--- a/gender_analysis/corpus.py
+++ b/gender_analysis/corpus.py
@@ -44,7 +44,7 @@ class Corpus(common.FileLoaderMixin):
         self.csv_path = csv_path
         self.path_to_files = path_to_files
         self.documents = []
-        self._metadata_fields = []
+        self.metadata_fields = []
 
         if self.path_to_files.suffix == '.pgz':
             pickle_data = common.load_pickle(self.path_to_files)
@@ -52,7 +52,7 @@ class Corpus(common.FileLoaderMixin):
             self.metadata_fields = pickle_data.metadata
         elif self.path_to_files.suffix == '' and not self.csv_path:
             files = listdir(self.path_to_files)
-            self._metadata_fields = ['filename', 'filepath']
+            self.metadata_fields = ['filename', 'filepath']
             for file in files:
                 if file.endswith('.txt'):
                     metadata_dict = {'filename': file, 'filepath': self.path_to_files / file}
@@ -61,10 +61,6 @@ class Corpus(common.FileLoaderMixin):
             self.documents = self._load_documents()
         else:
             raise ValueError(f'path_to_files must lead to a a previously pickled corpus or directory of .txt files')
-
-    @property
-    def metadata_fields(self):
-        return self._metadata_fields
 
     def __len__(self):
         """
@@ -206,7 +202,7 @@ class Corpus(common.FileLoaderMixin):
             documents.append(this_document)
             metadata.update(list(document_metadata))
 
-        self._metadata_fields = list(metadata)
+        self.metadata_fields = list(metadata)
         return sorted(documents)
 
     def count_authors_by_gender(self, gender):

--- a/gender_analysis/document.py
+++ b/gender_analysis/document.py
@@ -231,7 +231,7 @@ class Document(common.FileLoaderMixin):
             text = self.load_file(file_path)
         except FileNotFoundError:
             err = "Could not find the document text file "
-            err += "at the expected location ({file_path})."
+            err += f"at the expected location ({file_path})."
             raise FileNotFoundError(err)
 
         return text


### PR DESCRIPTION
The get_corpus_metadata function in Corpus has been replaced by simply a call to Corpus.metadata_fields