### PR TITLE
Metadata can now be updated without reloading corpus

### DIFF
--- a/gender_analysis/corpus.py
+++ b/gender_analysis/corpus.py
@@ -53,6 +53,7 @@ class Corpus:
             pickle_data = common.load_pickle(self.path_to_files)
             self.documents = pickle_data.documents
             self.metadata_fields = pickle_data.metadata_fields
+
         elif self.path_to_files.suffix == '' and not self.csv_path:
             files = listdir(self.path_to_files)
             self.metadata_fields = ['filename', 'filepath']
@@ -60,8 +61,10 @@ class Corpus:
                 if file.endswith('.txt'):
                     metadata_dict = {'filename': file, 'filepath': self.path_to_files / file}
                     self.documents.append(Document(metadata_dict))
+
         elif self.csv_path and self.path_to_files.suffix == '':
             self.documents = self._load_documents()
+
         else:
             raise ValueError(f'path_to_files must lead to a previously pickled corpus or directory of .txt files')
 
@@ -539,15 +542,6 @@ class Corpus:
                         output.append((document.filename, passage))
                         count += 1
 
-        '''
-        random.shuffle(output)
-        print_count = 0
-        for entry in output:
-            if print_count == no_passages:
-                break
-            print_count += 1
-            print(entry)
-        '''
         if len(output) <= no_passages:
             return output
         return output[:no_passages]
@@ -588,6 +582,42 @@ class Corpus:
                 return document
 
         raise ValueError("Document not found")
+
+    def update_metadata(self, new_metadata_path):
+        """
+        Takes a filepath to a csv with new metadata and updates the metadata in the documents accordingly.
+        The new file does not need to contain every metadata field in the documents - only the fields that you wish to update.
+
+        :param new_metadata_path: Path to new metadata csv file
+        :return: None
+        """
+        metadata = set()
+        metadata.update(self.metadata_fields)
+
+        if isinstance(new_metadata_path, str):
+            new_metadata_path = Path(new_metadata_path)
+        if not isinstance(new_metadata_path, Path):
+            raise ValueError(f'new_metadata_path must be str or Path object, not type {type(new_metadata_path)}')
+
+        try:
+            csv_list = load_csv_to_list(new_metadata_path)
+        except FileNotFoundError:
+            err = "Could not find the metadata csv file for the "
+            err += f"corpus in the expected location ({self.csv_path})."
+            raise FileNotFoundError(err)
+        csv_reader = csv.DictReader(csv_list)
+
+        for document_metadata in csv_reader:
+            document_metadata = dict(document_metadata)
+            metadata.update(list(document_metadata))
+            try:
+                document = self.get_document('filename', document_metadata['filename'])
+            except ValueError:
+                raise ValueError(f"Document {document_metadata['filename']} not found in corpus")
+
+            document.update_metadata(document_metadata)
+
+        self.metadata_fields = list(metadata)
 
 
 if __name__ == '__main__':

--- a/gender_analysis/document.py
+++ b/gender_analysis/document.py
@@ -64,6 +64,7 @@ class Document:
         self._word_counts_counter = None
         self._word_count = None
 
+        # TODO: Does this really need to be here?
         if 'author_gender' in metadata_dict and self.author_gender not in {'female', 'male', 'non-binary', 'unknown', 'both'}:
             raise ValueError('Author gender has to be "female", "male" "non-binary," or "unknown" ',
                              f'but not {self.author_gender}. Full metadata: {metadata_dict}')
@@ -234,7 +235,6 @@ class Document:
             raise FileNotFoundError(err)
 
         return text
-
 
     def get_tokenized_text(self):
         """
@@ -487,3 +487,45 @@ class Document:
         text = nltk.word_tokenize(self.text)
         pos_tags = nltk.pos_tag(text)
         return pos_tags
+
+    def update_metadata(self, new_metadata):
+        """
+        Updates the metadata of the document without requiring a complete reloading of the text and other properties.
+        'filename' cannot be updated with this method.
+
+        :param new_metadata: dict of new metadata to apply to the document
+        :return:
+
+        >>> from gender_analysis.document import Document
+        >>> from gender_analysis.common import BASE_PATH
+        >>> from pathlib import Path
+        >>> metadata = {'filename': 'aanrud_longfrock.txt',
+        ...             'filepath': Path(BASE_PATH, 'testing', 'corpora', 'test_corpus', 'aanrud_longfrock.txt'),
+        ...             'date': '2098'}
+        >>> d = Document(metadata)
+        >>> new_metadata = {'date': 1903}
+        >>> d.update_metadata(new_metadata)
+        >>> d.date
+        1903
+
+        >>> new_attribute = {'cookies': 'chocolate chip'}
+        >>> d.update_metadata(new_attribute)
+        >>> d.cookies
+        'chocolate chip'
+        """
+
+        if not isinstance(new_metadata, dict):
+            raise ValueError(f'new_metadata must be a dictionary of metadata keys, not type {type(new_metadata)}')
+        if 'filename' in new_metadata and new_metadata['filename'] != self.filename:
+            raise KeyError(f'You cannot update the filename of a document; consider removing {str(self)} from the '
+                           f'Corpus object and adding the document again with the updated filename')
+
+        for key in new_metadata:
+            if key == 'date':
+                try:
+                    new_metadata[key] = int(new_metadata[key])
+                except ValueError:
+                    raise ValueError(f"the metadata field 'date' must be a number for document {self.filename}, not "
+                                     f"'{new_metadata['date']}'")
+            setattr(self, key, new_metadata[key])
+


### PR DESCRIPTION
The metadata of a corpus (or document) can now be updated as necessary, rather than requiring a full reload of the data.