### PR TITLE
Removed an error mandating that author_gender be from a certain list

### DIFF
--- a/gender_analysis/document.py
+++ b/gender_analysis/document.py
@@ -64,11 +64,6 @@ class Document:
         self._word_counts_counter = None
         self._word_count = None
 
-        # TODO: Does this really need to be here?
-        if 'author_gender' in metadata_dict and self.author_gender not in {'female', 'male', 'non-binary', 'unknown', 'both'}:
-            raise ValueError('Author gender has to be "female", "male" "non-binary," or "unknown" ',
-                             f'but not {self.author_gender}. Full metadata: {metadata_dict}')
-
         if not metadata_dict['filename'].endswith('.txt'):
             raise ValueError(
                 f'The document filename ', str(metadata_dict['filename']), 'does not end in .txt . Full metadata: '


### PR DESCRIPTION
This appears to be the only instance of it in the project, although there are some functions that rely on 'male' or 'female' as inputs, and removing the requirement might be more work than we can do at the moment (it appears to be hardcoded into a lot of the analysis methods).