### PR TITLE
Cleaned dependency_parsing.py

### DIFF
--- a/gender_analysis/analysis/dependency_parsing.py
+++ b/gender_analysis/analysis/dependency_parsing.py
@@ -89,83 +89,66 @@ def get_parser_download_if_not_present():
             os.remove(zip_path)
             print('Done!')
 
-    parser = StanfordDependencyParser(path_to_jar, path_to_models_jar)
+    parser = StanfordDependencyParser(str(path_to_jar), str(path_to_models_jar))
     return parser
 
 
-def pickle(document, parser, pickle_filepath='dep_tree.pgz'):
+def generate_dependency_tree(document, pickle_filepath=None):
     """
-    This function returns a pickled tree
+    This function returns the dependency tree for a given document.
+
     :param document: Document we are interested in
-    :param parser: Stanford parser object
-    :param pickle_filepath: filepath to store pickled dependency tree
-    :return: tree in pickle format
+    :param pickle_filepath: filepath to store pickled dependency tree, will not write a file if None
+    :return: dependency tree, represented as a nested list
+
     """
 
-    try:
-        tree = common.load_pickle(pickle_filepath)
-    except (IOError, FileNotFoundError):
-        sentences = sent_tokenize(document.text.lower().replace("\n", " "))
-        he_she_sentences = []
-        for sentence in sentences:
-            add_sentence = False
-            words = [word for word in word_tokenize(sentence)]
-            for word in words:
-                if word == "he" or word == "she" or word == "him" or word == "her":
-                    add_sentence = True
-            if add_sentence:
-                he_she_sentences.append(sentence)
-        sentences = he_she_sentences
-        result = parser.raw_parse_sents(sentences)
-        # dependency triples of the form ((head word, head tag), rel, (dep word, dep tag))
-        # link defining dependencies: https://nlp.stanford.edu/software/dependencies_manual.pdf
-        tree = list(result)
-        tree_list = []
-        i = 0
-        for sentence in tree:
-            tree_list.append([])
-            triples = list(next(sentence).triples())
-            for triple in triples:
-                tree_list[i].append(triple)
-            i += 1
-        tree = tree_list
+    parser = get_parser_download_if_not_present()
+    sentences = sent_tokenize(document.text.lower().replace("\n", " "))
+    he_she_sentences = []
+    for sentence in sentences:
+        add_sentence = False
+        words = [word for word in word_tokenize(sentence)]
+        for word in words:
+            if word == "he" or word == "she" or word == "him" or word == "her":
+                add_sentence = True
+        if add_sentence:
+            he_she_sentences.append(sentence)
+    sentences = he_she_sentences
+    result = parser.raw_parse_sents(sentences)
+
+    # dependency triples of the form ((head word, head tag), rel, (dep word, dep tag))
+    # link defining dependencies: https://nlp.stanford.edu/software/dependencies_manual.pdf
+    tree = list(result)
+    tree_list = []
+    i = 0
+    for sentence in tree:
+        tree_list.append([])
+        triples = list(next(sentence).triples())
+        for triple in triples:
+            tree_list[i].append(triple)
+        i += 1
+    tree = tree_list
+
+    if pickle_filepath is not None:
         common.store_pickle(tree, pickle_filepath)
+
     return tree
 
 
-def parse_document(document, parser):
+def get_male_pronoun_usages(tree):
     """
-    This function parses all sentences in the document
-    :param document: document object we want to analyze
-    :param parser: Stanford dependency parser
-    :return: list containing the following:
-    - Title of document
-    - Count of male pronoun subject occurrences
-    - Count of male pronoun object occurrences
-    - Count of female pronoun subject occurrences
-    - Count of female pronoun object occurrences
-    - List of adjectives describing male pronouns as one space-separated string
-    - List of verbs associated with male pronouns as one space-separated string
-    - List of adjectives describing female pronouns as one space-separated string
-    - List of verbs associated with female pronouns as one space-separated string
+    Returns a dictionary relating the occurrences of male pronouns as the
+    subject and object of a sentence.
 
-    >>> parser = get_parser("assets/stanford-parser.jar","assets/stanford-parser-3.9.1-models.jar")
-    >>> documents = Corpus('sample_novels').documents
-    >>> document_metadata = {'author': 'Hawthorne, Nathaniel', 'title': 'Scarlet Letter', 'date': '1900',
-    ...                   'filename': None, 'text': "He told her"}
-    >>> toy_novel = Document(document_metadata)
-    >>> parse_novel(toy_novel, parser)
-    ('Scarlet Letter', 1, 0, 0, 1, [], ['told'], [], [])
+    :param tree: dependency tree for a document, output of **generate_dependency_tree**
+    :return: Dictionary counting the times male pronouns are used as the subject and object,
+        formatted as {'subject': <int>, 'object': <int>}
 
     """
-    parser = get_parser_download_if_not_present()
-    tree = pickle(document, parser)
 
-    male_subj_count = male_obj_count = female_subj_count = female_obj_count = 0
-    female_adjectives = []
-    male_adjectives = []
-    female_verbs = []
-    male_verbs = []
+    male_obj_count = 0
+    male_subj_count = 0
 
     for sentence in tree:
         for triple in sentence:
@@ -173,45 +156,109 @@ def parse_document(document, parser):
                 male_subj_count += 1
             if triple[1] == "dobj" and triple[2][0] == "him":
                 male_obj_count += 1
+
+    return {'subject': male_subj_count, 'object': male_obj_count}
+
+
+def get_female_pronoun_usages(tree):
+    """
+    Returns a dictionary relating the occurrences of male pronouns as the
+    subject and object of a sentence.
+
+    :param tree: dependency tree for a document, output of **generate_dependency_tree**
+    :return: Dictionary counting the times male pronouns are used as the subject and object,
+        formatted as {'subject': <int>, 'object': <int>}
+
+    """
+
+    female_obj_count = 0
+    female_subj_count = 0
+
+    for sentence in tree:
+        for triple in sentence:
             if triple[1] == "nsubj" and triple[2][0] == "she":
                 female_subj_count += 1
             if triple[1] == "dobj" and triple[2][0] == "her":
                 female_obj_count += 1
+
+    return {'subject': female_subj_count, 'object': female_obj_count}
+
+
+def get_male_adjectives(tree):
+    """
+    Returns a list of adjectives describing male pronouns in the given dependency tree.
+
+    :param tree: dependency tree for a document, output of **generate_dependency_tree**
+    :return: List of adjectives as strings
+
+    """
+
+    male_adjectives = []
+    for sentence in tree:
+        for triple in sentence:
+            if triple[1] == "nsubj" and triple[0][1] == "JJ":
+                if triple[2][0] == "he":
+                    male_adjectives.append(triple[0][0])
+
+    return male_adjectives
+
+
+def get_female_adjectives(tree):
+    """
+    Returns a list of adjectives describing female pronouns in the given dependency tree.
+
+    :param tree: dependency tree for a document, output of **generate_dependency_tree**
+    :return: List of adjectives as strings
+
+    """
+
+    female_adjectives = []
+    for sentence in tree:
+        for triple in sentence:
             if triple[1] == "nsubj" and triple[0][1] == "JJ":
                 if triple[2][0] == "she":
                     female_adjectives.append(triple[0][0])
-                elif triple[2][0] == "he":
-                    male_adjectives.append(triple[0][0])
+
+    return female_adjectives
+
+
+def get_male_verbs(tree):
+    """
+    Returns a list of verbs describing male pronouns in the given dependency tree.
+
+    :param tree: dependency tree for a document, output of **generate_dependency_tree**
+    :return: List of verbs as strings
+
+    """
+
+    male_verbs = []
+
+    for sentence in tree:
+        for triple in sentence:
+            if triple[1] == "nsubj" and (triple[0][1] == "VBD" or triple[0][1] == "VB" or
+                                         triple[0][1] == "VBP" or triple[0][1] == "VBZ"):
+                if triple[2][0] == "he":
+                    male_verbs.append(triple[0][0])
+
+    return male_verbs
+
+
+def get_female_verbs(tree):
+    """
+    Returns a list of verbs describing female pronouns in the given dependency tree.
+
+    :param tree: dependency tree for a document, output of **generate_dependency_tree**
+    :return: List of verbs as strings
+
+    """
+
+    female_verbs = []
+
+    for sentence in tree:
+        for triple in sentence:
             if triple[1] == "nsubj" and (triple[0][1] == "VBD" or triple[0][1] == "VB" or
                                          triple[0][1] == "VBP" or triple[0][1] == "VBZ"):
                 if triple[2][0] == "she":
                     female_verbs.append(triple[0][0])
-                elif triple[2][0] == "he":
-                    male_verbs.append(triple[0][0])
 
-    return [document.title, male_subj_count, male_obj_count, female_subj_count, female_obj_count,
-            " ".join(male_adjectives), " ".join(male_verbs), " ".join(female_adjectives),
-            " ".join(female_verbs)]
-
-
-# def test_analysis():
-#     """
-#     This function contains all analysis code to be run (previously in main function)
-#     - First generates a Stanford NLP parser
-#     - Iterates over sample documents corpus and parses each document (performs analysis: gender pronoun
-#     count, list of adjectives, list of verbs)
-#     - Writes output to dependency_analysis_results.csv
-#     """
-#
-#     parser = get_parser("assets/stanford-parser.jar", "assets/stanford-parser-3.9.1-models.jar")
-#     documents = Corpus('sample_novels').documents
-#     for document in documents:
-#         try:
-#             row = parse_document(document, parser)
-#             print(row)
-#             with open('dependency_analysis_results.csv', mode='w') as results_file:
-#                 writer = csv.writer(results_file, delimiter=',', quotechar='"',
-#                                              quoting=csv.QUOTE_MINIMAL)
-#                 writer.writerow(row)
-#         except OSError:
-#             continue
+    return female_verbs


### PR DESCRIPTION
dependency_parsing.parse_document is now split up into its various parts for convenience and readability.

For some reason, StanfordDependencyParser requires strings as arguments rather than Path objects, so that has been fixed as well.