### PR TITLE
Created Gender and Pronoun Structures

### DIFF
--- a/gender_analysis/__init__.py
+++ b/gender_analysis/__init__.py
@@ -3,8 +3,10 @@ __all__ = [
     'corpus',
     'document',
     'analysis',
+    'pronouns',
 ]
 
 from gender_analysis import *
 from gender_analysis.corpus import Corpus
 from gender_analysis.document import Document
+from gender_analysis.pronouns import PronounSeries

--- a/gender_analysis/common.py
+++ b/gender_analysis/common.py
@@ -7,10 +7,12 @@ from pathlib import Path
 import nltk
 import seaborn as sns
 
+from gender_analysis.pronouns import PronounSeries
+
 BASE_PATH = Path(os.path.abspath(os.path.dirname(__file__)))
 TEST_DATA_PATH = Path(BASE_PATH, 'testing', 'test_data')
-MASC_WORDS = set(('he', 'his', 'him', 'himself'))
-FEM_WORDS = set(('she', 'her', 'hers', 'herself'))
+MASC_WORDS = PronounSeries('Masc', {'he', 'his', 'him', 'himself'})
+FEM_WORDS = PronounSeries('Fem', {'she', 'her', 'hers', 'herself'})
 
 
 def load_csv_to_list(file_path):

--- a/gender_analysis/gender.py
+++ b/gender_analysis/gender.py
@@ -1,0 +1,26 @@
+from gender_analysis.pronouns import PronounSeries
+
+
+class Gender:
+    """
+    Defines a gender that will be operated on in analysis functions
+    """
+
+    def __init__(self, identifier, pronouns):
+        """
+        Initializes a Gender object that can be used for comparing and contrasting in the
+        analysis functions.
+
+        The gender accepts one or more `PronounSeries` that will be used to identify the gender.
+
+        :param identifier: String name of the gender
+        :param pronouns: `PronounSeries` or collection of `PronounSeries` that the gender uses.
+        """
+
+        self.identifier = identifier
+
+        # Allow the user to input a single PronounSeries if only one applies
+        if type(pronouns) == PronounSeries:
+            self.pronouns = {pronouns}
+        else:
+            self.pronouns = set(pronouns)

--- a/gender_analysis/gender.py
+++ b/gender_analysis/gender.py
@@ -6,7 +6,7 @@ class Gender:
     Defines a gender that will be operated on in analysis functions
     """
 
-    def __init__(self, identifier, pronouns):
+    def __init__(self, identifier, pronoun_series):
         """
         Initializes a Gender object that can be used for comparing and contrasting in the
         analysis functions.
@@ -14,13 +14,125 @@ class Gender:
         The gender accepts one or more `PronounSeries` that will be used to identify the gender.
 
         :param identifier: String name of the gender
-        :param pronouns: `PronounSeries` or collection of `PronounSeries` that the gender uses.
+        :param pronoun_series: `PronounSeries` or collection of `PronounSeries` that the gender uses.
         """
 
         self.identifier = identifier
 
         # Allow the user to input a single PronounSeries if only one applies
-        if type(pronouns) == PronounSeries:
-            self.pronouns = {pronouns}
+        if type(pronoun_series) == PronounSeries:
+            self.pronoun_series = {pronoun_series}
         else:
-            self.pronouns = set(pronouns)
+            self.pronoun_series = set(pronoun_series)
+
+    def __repr__(self):
+        """
+        :return: A console-friendly representation of the gender
+
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> from gender_analysis.gender import Gender
+        >>> fem_pronouns = PronounSeries('Fem', {'she', 'her', 'hers'})
+        >>> Gender('Female', fem_pronouns)
+        <Female: {<Fem: ['her', 'hers', 'she']>}>
+        """
+
+        return f'<{self.identifier}: {self.pronoun_series}>'
+
+    def __str__(self):
+        """
+        :return: A string representation of the gender
+
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> from gender_analysis.gender import Gender
+        >>> fem_pronouns = PronounSeries('Fem', {'she', 'her', 'hers'})
+        >>> str(Gender('Female', fem_pronouns))
+        'Female'
+        """
+
+        return self.identifier
+
+    def __hash__(self):
+        """
+        Allows the Gender object to be hashed
+        """
+
+        return self.identifier.__hash__()
+
+    def __eq__(self, other):
+        """
+        Performs a check to see whether two `Gender`s are equivalent. This is true if and only
+        if the `Gender`s' identifiers and pronoun series are identical.
+
+        Note that this comparison works:
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> from gender_analysis.gender import Gender
+        >>> fem_pronouns = PronounSeries('Fem', {'she', 'her', 'hers'})
+        >>> female = Gender('Female', fem_pronouns)
+        >>> another_female = Gender('Female', fem_pronouns)
+        >>> female == another_female
+        True
+
+        But this one does not:
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> from gender_analysis.gender import Gender
+        >>> they_series = PronounSeries('They', {'they', 'their', 'theirs'})
+        >>> xe_series = PronounSeries('Xe', {'xe', 'xer', 'xis'})
+        >>> androgynous_1 = Gender('NB', they_series)
+        >>> androgynous_2 = Gender('NB', xe_series)
+        >>> androgynous_1 == androgynous_2
+        False
+
+        :param other: The other `Gender` object to compare
+        :return: `True` if the `Gender`s are the same, `False` otherwise
+        """
+
+        return (
+            self.identifier == other.identifier and
+            self.pronoun_series == other.pronoun_series
+        )
+
+    def uses_pronoun(self, pronoun):
+        """
+        Performs a check for whether the gender uses the given pronoun. Note that this is
+        case-insensitive
+
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> from gender_analysis.gender import Gender
+        >>> they_series = PronounSeries('They', {'they', 'them', 'theirs'})
+        >>> xe_series = PronounSeries('Xe', {'Xe', 'Xer', 'Xis'})
+        >>> androgynous = Gender('Androgynous', [they_series, xe_series])
+        >>> androgynous.uses_pronoun('xer')
+        True
+        >>> androgynous.uses_pronoun('she')
+        False
+
+        :param pronoun: String representaion of the pronoun to check
+        :return: `True` if this gender uses the pronoun, `False` otherwise
+        """
+
+        # Check if the gender uses the pronoun in at least one of its series
+        for series in self.pronoun_series:
+            if pronoun in series:
+                return True
+
+        return False
+
+    def get_pronouns(self):
+        """
+        :return: A set containing all pronouns that this `Gender` uses
+
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> from gender_analysis.gender import Gender
+        >>> they_series = PronounSeries('They', {'they', 'them', 'theirs'})
+        >>> xe_series = PronounSeries('Xe', {'Xe', 'Xer', 'Xis'})
+        >>> androgynous = Gender('Androgynous', [they_series, xe_series])
+        >>> androgynous.get_pronouns() == {'they', 'them', 'theirs', 'xe', 'xer', 'xis'}
+        True
+        """
+
+        pronouns = set()
+        for series in self.pronoun_series:
+            for pronoun in series:
+                pronouns.add(pronoun)
+
+        return pronouns

--- a/gender_analysis/pronouns.py
+++ b/gender_analysis/pronouns.py
@@ -72,3 +72,33 @@ class PronounSeries:
         """
 
         return self.identifier + '-series'
+
+    def __hash__(self):
+        """
+        Makes the `PronounSeries` class hashable
+        """
+
+        return self.identifier.__hash__()
+
+    def __eq__(self, other):
+        """
+        Determines whether two `PronunSeries` are equal. Note that they are only equal if
+        they have the same identifier and the exact same set of pronouns.
+
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> fem_series = PronounSeries('Fem', {'she', 'her', 'hers'})
+        >>> second_fem_series = PronounSeries('Fem', {'she', 'her', 'hers'})
+        >>> fem_series == second_fem_series
+        True
+        >>> masc_series = PronounSeries('Masc', {'he', 'him', 'his'})
+        >>> fem_series == masc_series
+        False
+
+        :param other: The `PronounSeries` object to compare
+        :return: `True` if the two series are the same, `False` otherwise.
+        """
+        
+        return (
+            self.identifier == other.identifier and
+            self.pronouns == other.pronouns
+        )

--- a/gender_analysis/pronouns.py
+++ b/gender_analysis/pronouns.py
@@ -66,9 +66,9 @@ class PronounSeries:
         """
         >>> from gender_analysis.pronouns import PronounSeries
         >>> str(PronounSeries('Andy', {'Xe', 'Xis', 'Xer'}))
-        "Andy-series: ['xe', 'xer', 'xis']"
+        'Andy-series'
 
         :return: A string-representation of the pronoun series
         """
 
-        return f'{self.identifier}-series: {sorted(self.pronouns)}'
+        return self.identifier + '-series'

--- a/gender_analysis/pronouns.py
+++ b/gender_analysis/pronouns.py
@@ -1,0 +1,52 @@
+class PronounSeries:
+    """
+    A class that allows users to define a custom series of pronouns to be used in
+    `gender_analysis` functions
+    """
+
+    def __init__(self, identifier, pronouns):
+        """
+        Creates a new series of pronouns, designated by the given identifier. Pronouns
+        are any collection of strings that can be used to identify someone.
+
+        Note that pronouns are case-insensitive.
+
+        :param identifier: String used to identify what the particular series represents
+        :param pronouns: Iterable of Strings that are to be used as pronouns for this group
+        """
+
+        self.identifier = identifier
+
+        self.pronouns = set()
+        for pronoun in pronouns:
+            self.pronouns.add(pronoun.lower())
+
+    def __contains__(self, pronoun):
+        """
+        Checks to see if the given pronoun exists in this group. This check is case-insensitive
+
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> pronoun_group = PronounSeries('Andy', {'They', 'Them', 'Theirs', 'Themself'})
+        >>> 'they' in pronoun_group
+        True
+        >>> 'hers' in pronoun_group
+        False
+
+        :param pronoun: The pronoun to check for in this group
+        :return: true if the pronoun is in the group, false otherwise
+        """
+
+        return pronoun.lower() in self.pronouns
+
+    def __iter__(self):
+        """
+        Allows the user to iterate over all of the pronouns in this group. Pronouns
+        are returned in lowercase and order is not guaranteed.
+
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> pronoun_group = PronounSeries('Fem', {'She', 'Her', 'hers', 'herself'})
+        >>> sorted(list(pronoun_group))
+        ['her', 'hers', 'herself', 'she']
+
+        """
+        yield from self.pronouns

--- a/gender_analysis/pronouns.py
+++ b/gender_analysis/pronouns.py
@@ -82,7 +82,7 @@ class PronounSeries:
 
     def __eq__(self, other):
         """
-        Determines whether two `PronunSeries` are equal. Note that they are only equal if
+        Determines whether two `PronounSeries` are equal. Note that they are only equal if
         they have the same identifier and the exact same set of pronouns.
 
         >>> from gender_analysis.pronouns import PronounSeries
@@ -97,7 +97,7 @@ class PronounSeries:
         :param other: The `PronounSeries` object to compare
         :return: `True` if the two series are the same, `False` otherwise.
         """
-        
+
         return (
             self.identifier == other.identifier and
             self.pronouns == other.pronouns

--- a/gender_analysis/pronouns.py
+++ b/gender_analysis/pronouns.py
@@ -45,8 +45,30 @@ class PronounSeries:
 
         >>> from gender_analysis.pronouns import PronounSeries
         >>> pronoun_group = PronounSeries('Fem', {'She', 'Her', 'hers', 'herself'})
-        >>> sorted(list(pronoun_group))
+        >>> sorted(pronoun_group)
         ['her', 'hers', 'herself', 'she']
 
         """
         yield from self.pronouns
+
+    def __repr__(self):
+        """
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> PronounSeries('Masc', {'he', 'him', 'his'})
+        <Masc: ['he', 'him', 'his']>
+
+        :return: A console-friendly representation of the pronoun series
+        """
+
+        return f'<{self.identifier}: {sorted(self.pronouns)}>'
+
+    def __str__(self):
+        """
+        >>> from gender_analysis.pronouns import PronounSeries
+        >>> str(PronounSeries('Andy', {'Xe', 'Xis', 'Xer'}))
+        "Andy-series: ['xe', 'xer', 'xis']"
+
+        :return: A string-representation of the pronoun series
+        """
+
+        return f'{self.identifier}-series: {sorted(self.pronouns)}'


### PR DESCRIPTION
This PR creates a `Gender` and `PronounSeries` class that allows for a much wider spectrum of gender and pronoun analyses. This lays the groundwork for #102, but does not change any of the actual analyses functions mentioned in that issue. 

The only user-facing change for this PR is that `MASC_WORDS` and `FEM_WORDS` in `common.py` use the new `ProunounSeries` structure, with the intention that these will be replaced with male and female `Gender` objects once the analysis functions support them.