### PR TITLE
Remove Client-Facing Counter Objects

### DIFF
--- a/gender_analysis/analysis/dunning.py
+++ b/gender_analysis/analysis/dunning.py
@@ -101,17 +101,17 @@ def dunn_individual_word_by_corpus(corpus1, corpus2, word):
 
 def dunning_total(counter1, counter2, pickle_filepath=None):
     """
-    Runs dunning_individual on words shared by both counter objects
-    (-) end of spectrum is words for counter_2
-    (+) end of spectrum is words for counter_1
+    Runs dunning_individual on words shared by both dictionaries
+    (-) end of spectrum is words for counter2
+    (+) end of spectrum is words for counter1
     the larger the magnitude of the number, the more distinctive that word is in its
     respective counter object
 
     use pickle_filepath to store the result so it only has to be calculated once and can be
     used for multiple analyses.
 
-    :param counter1: Python Counter object
-    :param counter2: Python Counter object
+    :param counter1: Python Dictionary
+    :param counter2: Python Dictionary
     :param pickle_filepath: Filepath to store pickled results; will not save output if None
     :return: Dictionary
 
@@ -142,7 +142,7 @@ def dunning_total(counter1, counter2, pickle_filepath=None):
     # get word total in respective counters
     for word1 in counter1:
         total_words_counter1 += counter1[word1]
-    for word2 in  counter2:
+    for word2 in counter2:
         total_words_counter2 += counter2[word2]
 
     # dictionary where results will be returned

--- a/gender_analysis/analysis/gender_adjective.py
+++ b/gender_analysis/analysis/gender_adjective.py
@@ -23,7 +23,7 @@ def find_gender_adj(document, female):
     ...                   'filename': 'test_text_7.txt', 'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_7.txt')}
     >>> scarlett = document.Document(document_metadata)
     >>> find_gender_adj(scarlett, False)
-    Counter({'handsome': 3, 'sad': 1})
+    {'handsome': 3, 'sad': 1}
 
     """
     output = Counter()
@@ -61,7 +61,7 @@ def find_gender_adj(document, female):
                 word = words[tag_index]
                 output[word] += 1
 
-    return output
+    return dict(output)
 
 
 def find_male_adj(document):
@@ -79,7 +79,7 @@ def find_male_adj(document):
    ...                   'filename': 'test_text_8.txt', 'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_8.txt')}
    >>> scarlett = document.Document(document_metadata)
    >>> find_male_adj(scarlett)
-   Counter({'handsome': 3, 'sad': 1})
+   {'handsome': 3, 'sad': 1}
 
     """
     return find_gender_adj(document, False)
@@ -100,7 +100,7 @@ def find_female_adj(document):
     ...                   'filename': 'test_text_9.txt', 'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_9.txt')}
     >>> scarlett = document.Document(document_metadata)
     >>> find_female_adj(scarlett)
-    Counter({'beautiful': 3, 'sad': 1})
+    {'beautiful': 3, 'sad': 1}
 
     """
 
@@ -157,12 +157,12 @@ def merge(novel_adj_dict, full_adj_dict):
 
     :param novel_adj_dict: dictionary of adjectives/#occurrences for one novel
     :param full_adj_dict: dictionary of adjectives/#occurrences for multiple novels
-    :return: Counter object that merges both dictionaries
+    :return: dictionary object that merges both dictionaries
 
     >>> novel_adj_dict = {'hello': 5, 'hi': 7, 'hola': 9, 'bonjour': 2}
     >>> full_adj_dict = {'hello': 15, 'bienvenue': 3, 'hi': 23}
     >>> merge(novel_adj_dict, full_adj_dict)
-    Counter({'hi': 30, 'hello': 20, 'hola': 9, 'bienvenue': 3, 'bonjour': 2})
+    {'hello': 20, 'bienvenue': 3, 'hi': 30, 'hola': 9, 'bonjour': 2}
 
     """
 
@@ -170,7 +170,7 @@ def merge(novel_adj_dict, full_adj_dict):
     for adj in list(novel_adj_dict.keys()):
         merge_result[adj] += novel_adj_dict[adj]
 
-    return merge_result
+    return dict(merge_result)
 
 
 def merge_raw_results(full_results):

--- a/gender_analysis/analysis/gender_adjective.py
+++ b/gender_analysis/analysis/gender_adjective.py
@@ -1,4 +1,5 @@
 from statistics import median
+from collections import Counter
 from more_itertools import windowed
 import nltk
 
@@ -22,10 +23,10 @@ def find_gender_adj(document, female):
     ...                   'filename': 'test_text_7.txt', 'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_7.txt')}
     >>> scarlett = document.Document(document_metadata)
     >>> find_gender_adj(scarlett, False)
-    {'handsome': 3, 'sad': 1}
+    Counter({'handsome': 3, 'sad': 1})
 
     """
-    output = {}
+    output = Counter()
     text = document.get_tokenized_text()
 
     if female:
@@ -58,10 +59,8 @@ def find_gender_adj(document, female):
         for tag_index, tag in enumerate(tags):
             if tags[tag_index][1] == "JJ" or tags[tag_index][1] == "JJR" or tags[tag_index][1] == "JJS":
                 word = words[tag_index]
-                if word in output.keys():
-                    output[word] += 1
-                else:
-                    output[word] = 1
+                output[word] += 1
+
     return output
 
 
@@ -80,7 +79,7 @@ def find_male_adj(document):
    ...                   'filename': 'test_text_8.txt', 'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_8.txt')}
    >>> scarlett = document.Document(document_metadata)
    >>> find_male_adj(scarlett)
-   {'handsome': 3, 'sad': 1}
+   Counter({'handsome': 3, 'sad': 1})
 
     """
     return find_gender_adj(document, False)
@@ -101,7 +100,7 @@ def find_female_adj(document):
     ...                   'filename': 'test_text_9.txt', 'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_9.txt')}
     >>> scarlett = document.Document(document_metadata)
     >>> find_female_adj(scarlett)
-    {'beautiful': 3, 'sad': 1}
+    Counter({'beautiful': 3, 'sad': 1})
 
     """
 
@@ -289,7 +288,7 @@ def get_top_adj(full_results, num):
     """
     Takes dictionary of results from run_adj_analysis and number of top results to return.
     Returns the top num adjectives associated with male pronouns and female pronouns.
-    
+
     :param full_results: dictionary from result of run_adj_analysis
     :param num: number of top results to return per gender
     :return: tuple of lists of top adjectives associated with male pronouns and female pronouns, respectively

--- a/gender_analysis/analysis/gender_adjective.py
+++ b/gender_analysis/analysis/gender_adjective.py
@@ -157,21 +157,20 @@ def merge(novel_adj_dict, full_adj_dict):
 
     :param novel_adj_dict: dictionary of adjectives/#occurrences for one novel
     :param full_adj_dict: dictionary of adjectives/#occurrences for multiple novels
-    :return: full_results dictionary with novel_results merged in
+    :return: Counter object that merges both dictionaries
 
     >>> novel_adj_dict = {'hello': 5, 'hi': 7, 'hola': 9, 'bonjour': 2}
     >>> full_adj_dict = {'hello': 15, 'bienvenue': 3, 'hi': 23}
     >>> merge(novel_adj_dict, full_adj_dict)
-    {'hello': 20, 'bienvenue': 3, 'hi': 30, 'hola': 9, 'bonjour': 2}
+    Counter({'hi': 30, 'hello': 20, 'hola': 9, 'bienvenue': 3, 'bonjour': 2})
 
     """
+
+    merge_result = Counter(full_adj_dict)
     for adj in list(novel_adj_dict.keys()):
-        adj_count = novel_adj_dict[adj]
-        if adj in list(full_adj_dict.keys()):
-            full_adj_dict[adj] += adj_count
-        else:
-            full_adj_dict[adj] = adj_count
-    return full_adj_dict
+        merge_result[adj] += novel_adj_dict[adj]
+
+    return merge_result
 
 
 def merge_raw_results(full_results):

--- a/gender_analysis/analysis/gender_frequency.py
+++ b/gender_analysis/analysis/gender_frequency.py
@@ -1,5 +1,3 @@
-from collections import Counter
-
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -29,10 +27,10 @@ def get_count_words(document, words):
     ...                      'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_2.txt')}
     >>> doc = document.Document(document_metadata)
     >>> get_count_words(doc, ['sad', 'and'])
-    Counter({'sad': 4, 'and': 4})
+    {'sad': 4, 'and': 4}
 
     """
-    dic_word_counts = Counter()
+    dic_word_counts = dict()
     for word in words:
         dic_word_counts[word] = document.get_count_of_word(word)
     return dic_word_counts
@@ -80,17 +78,17 @@ def get_comparative_word_freq(freqs):
 def get_counts_by_pos(freqs):
     """
     This functions returns a dictionary where each key is a part of speech tag (e.g. 'NN' for nouns)
-    and the value is a counter object of words of that part of speech and their frequencies.
+    and the value is a dictionary of words of that part of speech and their frequencies.
     It also filters out words like "is", "the". We used `nltk`'s stop words function for filtering.
 
-    :param freqs: Counter object of words mapped to their word count
-    :return: dictionary with key as part of speech, value as Counter object of words
+    :param freqs: dictionary of words mapped to their word count
+    :return: dictionary with key as part of speech, value as dictionary of words
         (of that part of speech) mapped to their word count
 
-    >>> get_counts_by_pos(Counter({'baked':1,'chair':3,'swimming':4}))
-    {'VBN': Counter({'baked': 1}), 'NN': Counter({'chair': 3}), 'VBG': Counter({'swimming': 4})}
-    >>> get_counts_by_pos(Counter({'is':10,'usually':7,'quietly':42}))
-    {'RB': Counter({'quietly': 42, 'usually': 7})}
+    >>> get_counts_by_pos({'baked':1,'chair':3,'swimming':4})
+    {'VBN': {'baked': 1}, 'NN': {'chair': 3}, 'VBG': {'swimming': 4}}
+    >>> get_counts_by_pos({'is':10,'usually':7,'quietly':42})
+    {'RB': {'usually': 7, 'quietly': 42}}
 
     """
     common.download_nltk_package_if_not_present('corpora/stopwords')
@@ -105,7 +103,7 @@ def get_counts_by_pos(freqs):
             tag = nltk.pos_tag([word])[0][1]
             # add that word to the counter object in the relevant dict entry
             if tag not in sorted_words.keys():
-                sorted_words[tag] = Counter({word:freqs[word]})
+                sorted_words[tag] = {word: freqs[word]}
             else:
                 sorted_words[tag].update({word: freqs[word]})
     return sorted_words

--- a/gender_analysis/analysis/gender_frequency.py
+++ b/gender_analysis/analysis/gender_frequency.py
@@ -29,10 +29,10 @@ def get_count_words(document, words):
     ...                      'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_2.txt')}
     >>> doc = document.Document(document_metadata)
     >>> get_count_words(doc, ['sad', 'and'])
-    {'sad': 4, 'and': 4}
+    Counter({'sad': 4, 'and': 4})
 
     """
-    dic_word_counts = {}
+    dic_word_counts = Counter()
     for word in words:
         dic_word_counts[word] = document.get_count_of_word(word)
     return dic_word_counts

--- a/gender_analysis/corpus.py
+++ b/gender_analysis/corpus.py
@@ -337,9 +337,10 @@ class Corpus:
 
     def get_wordcount_counter(self):
         """
-        This function returns a Counter object that stores how many times each word appears in the corpus.
+        This function returns a Dictionary that stores how many times each word appears in
+        the corpus.
 
-        :return: Python Counter object
+        :return: Python Dictionary object
 
         >>> from gender_analysis.corpus import Corpus
         >>> from gender_analysis.common import TEST_DATA_PATH
@@ -355,7 +356,7 @@ class Corpus:
         for current_document in self.documents:
             document_counter = current_document.get_wordcount_counter()
             corpus_counter += document_counter
-        return corpus_counter
+        return dict(corpus_counter)
 
     def get_field_vals(self, field):
         """

--- a/gender_analysis/document.py
+++ b/gender_analysis/document.py
@@ -361,11 +361,12 @@ class Document:
 
     def get_wordcount_counter(self):
         """
-        Returns a counter object of all of the words in the text.
+        Returns a dictionary counting of all of the words in the text.
 
-        If this is your first time running this method, it may take a moment to perform a count in the document.
+        If this is your first time running this method, it may take a moment to perform a
+        count in the document.
 
-        :return: Python Counter object
+        :return: Dicitonary that contains all of the wordcounts in this `Document`
 
         >>> from gender_analysis import document
         >>> from pathlib import Path
@@ -374,18 +375,18 @@ class Document:
         ...                   'filename': 'test_text_10.txt', 'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_10.txt')}
         >>> scarlett = document.Document(document_metadata)
         >>> scarlett.get_wordcount_counter()
-        Counter({'was': 2, 'convicted': 2, 'hester': 1, 'of': 1, 'adultery': 1})
+        {'was': 2, 'convicted': 2, 'hester': 1, 'of': 1, 'adultery': 1}
 
         """
 
         # If word_counts were not previously initialized, do it now and store it for the future.
         if not self._word_counts_counter:
             self._word_counts_counter = Counter(self.get_tokenized_text())
-        return self._word_counts_counter
+        return dict(self._word_counts_counter)
 
     def words_associated(self, word):
         """
-        Returns a Counter of the words found after a given word.
+        Returns a dictionary counter of the words found after a given word.
 
         In the case of double/repeated words, the counter would include the word itself and the next
         new word.
@@ -393,7 +394,7 @@ class Document:
         Note: words always return lowercase.
 
         :param word: Single word to search for in the document's text
-        :return: a Python Counter() object with {associated_word: occurrences}
+        :return: a Python dictionary object with {associated_word: occurrences}
 
         >>> from gender_analysis import document
         >>> from pathlib import Path
@@ -402,7 +403,7 @@ class Document:
         ...                   'filename': 'test_text_11.txt', 'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_11.txt')}
         >>> scarlett = document.Document(document_metadata)
         >>> scarlett.words_associated("his")
-        Counter({'cigarette': 1, 'speech': 1})
+        {'cigarette': 1, 'speech': 1}
 
         """
         word = word.lower()
@@ -416,7 +417,7 @@ class Document:
                 check = False
             if w == word:
                 check = True
-        return word_count
+        return dict(word_count)
 
     def get_word_windows(self, search_terms, window_size=2):
         """
@@ -428,7 +429,7 @@ class Document:
 
         :param search_terms: String or list of strings to search for
         :param window_size: integer representing number of words to search for in either direction
-        :return: Python Counter object
+        :return: Python Dictionary object
 
         >>> from gender_analysis.document import Document
         >>> from pathlib import Path
@@ -440,12 +441,12 @@ class Document:
         search_terms can be either a string...
 
         >>> scarlett.get_word_windows("his", window_size=2)
-        Counter({'he': 1, 'lit': 1, 'cigarette': 1, 'and': 1, 'then': 1, 'began': 1, 'speech': 1, 'which': 1})
+        {'he': 1, 'lit': 1, 'cigarette': 1, 'and': 1, 'then': 1, 'began': 1, 'speech': 1, 'which': 1}
 
         ... or a list of strings.
 
         >>> scarlett.get_word_windows(['purse', 'tears'])
-        Counter({'her': 2, 'of': 1, 'and': 1, 'handed': 1, 'proposal': 1, 'drowned': 1, 'the': 1})
+        {'her': 2, 'of': 1, 'and': 1, 'handed': 1, 'proposal': 1, 'drowned': 1, 'the': 1}
 
         """
 
@@ -462,7 +463,7 @@ class Document:
                     if surrounding_word not in search_terms:
                         counter[surrounding_word] += 1
 
-        return counter
+        return dict(counter)
 
     def get_word_freq(self, word):
         """

--- a/gender_analysis/document.py
+++ b/gender_analysis/document.py
@@ -375,7 +375,7 @@ class Document:
         ...                   'filename': 'test_text_10.txt', 'filepath': Path(common.TEST_DATA_PATH, 'document_test_files', 'test_text_10.txt')}
         >>> scarlett = document.Document(document_metadata)
         >>> scarlett.get_wordcount_counter()
-        {'was': 2, 'convicted': 2, 'hester': 1, 'of': 1, 'adultery': 1}
+        {'hester': 1, 'was': 2, 'convicted': 2, 'of': 1, 'adultery': 1}
 
         """
 
@@ -446,7 +446,7 @@ class Document:
         ... or a list of strings.
 
         >>> scarlett.get_word_windows(['purse', 'tears'])
-        {'her': 2, 'of': 1, 'and': 1, 'handed': 1, 'proposal': 1, 'drowned': 1, 'the': 1}
+        {'of': 1, 'her': 2, 'and': 1, 'handed': 1, 'proposal': 1, 'drowned': 1, 'the': 1}
 
         """
 


### PR DESCRIPTION
The analysis functions (along with `Corpus` and `Document` classes) used a mix of dictionaries and `Counter` objects for their return values. This has now been standardized to only returning dictionary objects, although `Counter` objects are still used internally.