### PR TITLE
Removed `guess_author_gender` and related fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 chardet
 clint
 dh_testers
-gender-guesser==0.4.0
 matplotlib
 more-itertools
 nltk


### PR DESCRIPTION
As mentioned in #96, this removes the `guess_author_genders` function and references to it. There was a package requirement that was also removed because it is no longer needed.