### PR TITLE
Updated __repr__ function in Gender.py

### DIFF
--- a/gender_analysis/common.py
+++ b/gender_analysis/common.py
@@ -375,6 +375,7 @@ def create_path_object_and_directories(output_dir, filename=None):
 
     except OSError:
         print("Could not create the correct file and path")
+        return None
 
 
 if __name__ == '__main__':

--- a/gender_analysis/gender.py
+++ b/gender_analysis/gender.py
@@ -52,7 +52,7 @@ class Gender:
         <Female: {<Fem: ['her', 'hers', 'she']>}>
         """
 
-        return f'<{self.label}: {self.pronoun_series}>'
+        return f'<{self.label}>'
 
     def __str__(self):
         """

--- a/gender_analysis/gender.py
+++ b/gender_analysis/gender.py
@@ -49,7 +49,7 @@ class Gender:
         >>> from gender_analysis.gender import Gender
         >>> fem_pronouns = PronounSeries('Fem', {'she', 'her', 'hers'}, subj='she', obj='her')
         >>> Gender('Female', fem_pronouns)
-        <Female: {<Fem: ['her', 'hers', 'she']>}>
+        <Female>
         """
 
         return f'<{self.label}>'


### PR DESCRIPTION
The old `__repr__` function in `Gender.py` listed out all of the pronoun series associated with the objected as well as its label, but that tended to clutter things up. This has been switched over to a much cleaner version where only the label is displayed in the console