### PR TITLE
Move sword removal higher up in method calls

### DIFF
--- a/gender_analysis/analysis/proximity.py
+++ b/gender_analysis/analysis/proximity.py
@@ -17,11 +17,11 @@ GenderTokenResponse = Union[GenderTokenCounters, GenderTokenSequence]
 KeyGenderTokenResponse = Dict[Union[str, int], GenderTokenResponse]
 
 
-def _apply_kwargs(key_gender_token_counters: Dict[Union[str, int], GenderTokenCounters],
-                  diff: bool,
-                  sort: bool,
-                  limit: int,
-                  remove_swords: bool) -> KeyGenderTokenResponse:
+def _apply_result_filters(key_gender_token_counters: Dict[Union[str, int], GenderTokenCounters],
+                          diff: bool,
+                          sort: bool,
+                          limit: int,
+                          remove_swords: bool) -> KeyGenderTokenResponse:
     """
     A private helper function for applying optional keyword arguments to the output of
     GenderProximityAnalysis methods, allowing the user to sort, diff, limit, and remove stopwords
@@ -36,14 +36,14 @@ def _apply_kwargs(key_gender_token_counters: Dict[Union[str, int], GenderTokenCo
 
     >>> test_counter_1 = Counter({'foo': 1, 'bar': 2, 'own': 2})
     >>> test_counter_2 = Counter({'foo': 5, 'baz': 2})
-    >>> test_input = {'doc': {'Male': test_counter_1, 'Female': test_counter_2}}
-    >>> _apply_kwargs(test_input, diff=True, sort=False, limit=10, remove_swords=False).get('doc')
+    >>> test = {'doc': {'Male': test_counter_1, 'Female': test_counter_2}}
+    >>> _apply_result_filters(test, diff=True, sort=False, limit=10, remove_swords=False).get('doc')
     {'Male': Counter({'bar': 2, 'own': 2, 'foo': -4}), 'Female': Counter({'foo': 4, 'baz': 2})}
-    >>> _apply_kwargs(test_input, diff=False, sort=True, limit=10, remove_swords=False).get('doc')
+    >>> _apply_result_filters(test, diff=False, sort=True, limit=10, remove_swords=False).get('doc')
     {'Male': [('bar', 2), ('own', 2), ('foo', 1)], 'Female': [('foo', 5), ('baz', 2)]}
-    >>> _apply_kwargs(test_input, diff=False, sort=False, limit=10, remove_swords=True).get('doc')
+    >>> _apply_result_filters(test, diff=False, sort=False, limit=10, remove_swords=True).get('doc')
     {'Male': Counter({'bar': 2, 'foo': 1}), 'Female': Counter({'foo': 5, 'baz': 2})}
-    >>> _apply_kwargs(test_input, diff=True, sort=True, limit=10, remove_swords=False).get('doc')
+    >>> _apply_result_filters(test, diff=True, sort=True, limit=10, remove_swords=False).get('doc')
     {'Male': [('bar', 2), ('own', 2), ('foo', -4)], 'Female': [('foo', 4), ('baz', 2)]}
     """
 
@@ -423,7 +423,11 @@ class GenderProximityAnalyzer:
                     [self._results[document][gender_label], output[bin_year][gender_label]]
                 )
 
-        return _apply_kwargs(output, sort=sort, diff=diff, limit=limit, remove_swords=remove_swords)
+        return _apply_result_filters(output,
+                                     sort=sort,
+                                     diff=diff,
+                                     limit=limit,
+                                     remove_swords=remove_swords)
 
     def by_document(self,
                     sort: bool = False,
@@ -458,7 +462,11 @@ class GenderProximityAnalyzer:
         for document in self._results:
             output[document.label] = self._results[document]
 
-        return _apply_kwargs(output, sort=sort, diff=diff, limit=limit, remove_swords=remove_swords)
+        return _apply_result_filters(output,
+                                     sort=sort,
+                                     diff=diff,
+                                     limit=limit,
+                                     remove_swords=remove_swords)
 
     def by_gender(self,
                   sort: bool = False,
@@ -569,7 +577,11 @@ class GenderProximityAnalyzer:
                     output[matching_key][gender_label]
                 ])
 
-        return _apply_kwargs(output, sort=sort, diff=diff, limit=limit, remove_swords=remove_swords)
+        return _apply_result_filters(output,
+                                     sort=sort,
+                                     diff=diff,
+                                     limit=limit,
+                                     remove_swords=remove_swords)
 
     def by_overlap(self) -> Dict[str, Sequence[int]]:
         """

--- a/gender_analysis/analysis/proximity.py
+++ b/gender_analysis/analysis/proximity.py
@@ -24,7 +24,7 @@ def _apply_kwargs(key_gender_token_counters: Dict[Union[str, int], GenderTokenCo
                   remove_swords: bool) -> KeyGenderTokenResponse:
     """
     A private helper function for applying optional keyword arguments to the output of
-    GenderProximityAnalysis, allowing the user to sort, diff, limit, and remove stopwords
+    GenderProximityAnalysis methods, allowing the user to sort, diff, limit, and remove stopwords
     from the output. These transformations do not mutate the input.
 
     :param key_gender_token_counters: a dictionary shaped Dict[Union[str, int], GenderTokenCounters]
@@ -56,37 +56,27 @@ def _apply_kwargs(key_gender_token_counters: Dict[Union[str, int], GenderTokenCo
             output[key] = gender_token_counters
 
         if diff:
-            output[key] = _diff_gender_token_counters(output[key], limit=limit, sort=sort)
-        elif sort:
+            output[key] = _diff_gender_token_counters(output[key])
+
+        if sort:
             output[key] = _sort_gender_token_counters(output[key], limit=limit)
 
     return output
 
 
-def _diff_gender_token_counters(gender_token_counters: GenderTokenCounters,
-                                sort: bool = False,
-                                limit: int = 10) -> GenderTokenResponse:
+def _diff_gender_token_counters(gender_token_counters: GenderTokenCounters) -> GenderTokenCounters:
     """
     A private helper function that determines the difference of token occurrences
     across multiple Genders.
 
     :param gender_token_counters: Dict[str, Counter]
-    :param sort: Optional[bool], return Dict[str, Sequence[Tuple[str, int]]]
-    :param limit: Optional[int], if sort=True, return n=limit number of items in descending order
 
     >>> token_frequency_1 = Counter({'foo': 1, 'bar': 2, 'baz': 4})
     >>> token_frequency_2 = Counter({'foo': 2, 'bar': 3, 'baz': 2})
     >>> test = {'Male': token_frequency_1, 'Female': token_frequency_2}
     >>> _diff_gender_token_counters(test).get('Male')
     Counter({'baz': 2, 'foo': -1, 'bar': -1})
-    >>> _diff_gender_token_counters(test, sort=True).get('Male')
-    [('baz', 2), ('foo', -1), ('bar', -1)]
-    >>> _diff_gender_token_counters(test, sort=True, limit=2).get('Male')
-    [('baz', 2), ('foo', -1)]
     """
-
-    if not isinstance(limit, int):
-        raise ValueError('limit must be of type int')
 
     difference_dict = {}
 
@@ -107,10 +97,7 @@ def _diff_gender_token_counters(gender_token_counters: GenderTokenCounters,
 
         difference_dict[gender] = current_difference
 
-    if sort:
-        return _sort_gender_token_counters(difference_dict, limit=limit)
-    else:
-        return difference_dict
+    return difference_dict
 
 
 def _generate_token_counter(document: Document,
@@ -525,8 +512,9 @@ class GenderProximityAnalyzer:
             output = _remove_swords(output)
 
         if diff:
-            output = _diff_gender_token_counters(output, limit=limit, sort=sort)
-        elif sort:
+            output = _diff_gender_token_counters(output)
+
+        if sort:
             output = _sort_gender_token_counters(output, limit=limit)
 
         self._by_gender[hashed_arguments] = output


### PR DESCRIPTION
# Overview
This PR refactors how stop words are removed in the `proximity` module and how the `diff` and `sort` optional arguments are applied in the method calls of `GenderProximityAnalyzer`. This change allows us to reduce duplicative code and further unit test the helper functions that support the analysis performed in `GenderProximityAnalyzer`.

Previously, stop words were removed in the module's private helper functions (`_diff_gender_token_counters` and `_sort_gender_token_counters`). These functions were only called if the user passed in the optional `diff=True` or `sort=True` arguments into the `GenderProximityAnalyzer`'s various instance methods, meaning that stop words could only be removed if a user passed in one of those optional arguments as well as the optional `remove_swords=True`. 

With this change, stop word removal as well as diffing and sorting take place in the new `_apply_kwargs` helper function, which is applied to the output of each of `GenderProximityAnalyzer`'s various method outputs. Users can now pass in simply `remove_swords=True` (which is now the default value for this optional argument) and the stop words are removed prior to any optional additional `diff` or `sort` functionality.

The upshot is that we can delete some code and allow users to perform the `remove_sword` functionality on any permutation of the datasets produced by `GenderProximityAnalyzer` instance methods.

While I was in here, I've also removed a few functions from `proximity.py`:
- `_sort_token_counter`: Previously, this helper function included the `remove_swords` functionality, but otherwise simply called `.most_common` on its `Counter` instance argument. Since this function no longer uses `remove_swords`, it has become unnecessary.
- `find_in_document_gender`, `find_in_document_male`, `find_in_document_female`: these functions were, more or less, duplicates of the old `find_male_adj`, `find_female_adj`, and `find_gender_adj` functions from the `gender_adjectives` module. They allow a use to generate `Counter` instances of token/count pairs for a single `Document` instance, bypassing the initialization of `GenderProximityAnalyzer`. Ultimately, I believe these functions are unnecessary. For instance:
```
analysis = find_in_document_male(document)
```

Is the equivalent of:
```
analysis = GenderProximityAnalyzer(document).by_gender().get('Male')
```

While the former does indeed present a more succinct interface, I think that it's more valuable to create a single, unified interface for all proximity analyses. Plus, it allows us to remove code.