### PR TITLE
Create analyzer interface (...again!)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, summer-urop-21-refactor ]
 
 jobs:
   test_coverage:

--- a/documentation/source/tutorial/tutorial.rst
+++ b/documentation/source/tutorial/tutorial.rst
@@ -95,7 +95,7 @@ list of stopwords sourced from NLTK:
 
 .. code-block:: python
 
-    >>> from gender_analysis.common import SWORDS_ENG as swords_eng
+    >>> from gender_analysis.text.common import SWORDS_ENG as swords_eng
     >>> for word in list(sleep_associations):
     >>> 	if word in swords_eng:
     >>>		del sleep_associations[word]

--- a/gender_analysis/analysis/__init__.py
+++ b/gender_analysis/analysis/__init__.py
@@ -5,7 +5,7 @@ __all__ = [
     'instance_distance',
     'metadata_visualizations',
     'proximity',
-    'text_analyzer',
+    'base_analyzers',
 ]
 
 from .dependency_parsing import *
@@ -14,4 +14,4 @@ from .gender_frequency import *
 from .instance_distance import *
 from .metadata_visualizations import *
 from .proximity import GenderProximityAnalyzer
-from .text_analyzer import CorpusAnalyzer
+from .base_analyzers import CorpusAnalyzer

--- a/gender_analysis/analysis/__init__.py
+++ b/gender_analysis/analysis/__init__.py
@@ -3,13 +3,15 @@ __all__ = [
     'dunning',
     'gender_frequency',
     'instance_distance',
-    'proximity',
     'metadata_visualizations',
+    'proximity',
+    'text_analyzer',
 ]
 
-from .metadata_visualizations import *
 from .dependency_parsing import *
 from .dunning import *
 from .gender_frequency import *
 from .instance_distance import *
+from .metadata_visualizations import *
 from .proximity import GenderProximityAnalyzer
+from .text_analyzer import CorpusAnalyzer

--- a/gender_analysis/analysis/base_analyzers.py
+++ b/gender_analysis/analysis/base_analyzers.py
@@ -12,11 +12,25 @@ class CorpusAnalyzer:
 
     Intended for topic-specific subclassing.
 
+    CorpusAnalyzers can be initialized with the path to a directory of text files
+    and, optionally, associated metadata. In this case, CorpusAnalyzer
+    creates and manages a Corpus object for you.
     >>> from gender_analysis.analysis import CorpusAnalyzer
     >>> from gender_analysis.testing.common import TEST_DATA_DIR
     >>> file_path = TEST_DATA_DIR / 'document_test_files'
     >>> metadata_csv_path = TEST_DATA_DIR / 'document_test_files' / 'document_test_files.csv'
     >>> analyzer = CorpusAnalyzer(file_path=file_path, csv_path=metadata_csv_path)
+    >>> type(analyzer.corpus), len(analyzer.corpus)
+    (<class 'gender_analysis.text.corpus.Corpus'>, 14)
+
+    Alternatively, you can initialize a CorpusAnalyzer using an existing Corpus object.
+    >>> from gender_analysis.analysis import CorpusAnalyzer
+    >>> from gender_analysis.text import Corpus
+    >>> from gender_analysis.testing.common import TEST_DATA_DIR
+    >>> file_path = TEST_DATA_DIR / 'document_test_files'
+    >>> metadata_csv_path = TEST_DATA_DIR / 'document_test_files' / 'document_test_files.csv'
+    >>> corpus = Corpus(file_path, csv_path=metadata_csv_path)
+    >>> analyzer = CorpusAnalyzer(corpus=corpus)
     >>> type(analyzer.corpus), len(analyzer.corpus)
     (<class 'gender_analysis.text.corpus.Corpus'>, 14)
     """
@@ -28,15 +42,16 @@ class CorpusAnalyzer:
         csv_path: str = None,
         name: str = None,
         pickle_path: str = None,
-        ignore_warnings: bool = False,
-    ):
+        ignore_warnings: bool = False
+    ) -> None:
+        """
+        Initializes a CorpusAnalyzer.
+        Subclasses are expected to extend the initialization routine to perform any initial
+        analysis that can be run at init time and be cached for later access.
+        """
         if corpus:
             self.corpus = corpus
-        else:
-            if not (file_path and csv_path):
-                # TODO(ra): real exception type, better message
-                raise Exception('You must pass a file_path and csv_path')
-
+        elif file_path:
             # Create a new corpus
             self.corpus = Corpus(
                 file_path,
@@ -45,6 +60,12 @@ class CorpusAnalyzer:
                 pickle_on_load=pickle_path,
                 ignore_warnings=ignore_warnings,
             )
+        else:
+            raise ValueError(
+                'You must initialize a CorpusAnalyzer with an existing corpus, '
+                'or with the file_path argument pointing to your data directory.'
+            )
+
 
     def get_word_counts(self, remove_swords: bool = False) -> Counter:
         """

--- a/gender_analysis/analysis/proximity.py
+++ b/gender_analysis/analysis/proximity.py
@@ -13,6 +13,8 @@ from gender_analysis.text.common import (
 from gender_analysis.gender.common import MALE, FEMALE, BINARY_GROUP
 from gender_analysis.gender.gender import Gender
 
+from gender_analysis.analysis.base_analyzers import CorpusAnalyzer
+
 GenderTokenCounters = Dict[str, Counter]
 GenderTokenSequence = Dict[str, Sequence[Tuple[str, int]]]
 GenderTokenResponse = Union[GenderTokenCounters, GenderTokenSequence]
@@ -289,7 +291,7 @@ def _sort_gender_token_counters(gender_token_counters: GenderTokenCounters,
     return output_gender_token_counters
 
 
-class GenderProximityAnalyzer:
+class GenderProximityAnalyzer(CorpusAnalyzer):
     """
     The GenderProximityAnalyzer instance finds word occurrences within a window around
     gendered pronouns. Helper methods are provided to organize and analyze those occurrences
@@ -300,17 +302,17 @@ class GenderProximityAnalyzer:
 
     Instance methods:
         by_date()
-        by_document()
+        by_document(
         by_gender()
         by_metadata()
         by_overlap()
     """
 
     def __init__(self,
-                 texts: Union[Document, Corpus, Sequence[Document]],
                  tags: Optional[Sequence[str]] = None,
                  genders: Optional[Sequence[Gender]] = None,
-                 word_window: int = 5) -> None:
+                 word_window: int = 5,
+                 **kwargs) -> None:
         """
         Initializes a GenderProximityAnalyzer object that can be used for retrieving
         analyses concerning the number of occurrences of specific words within a window of
@@ -321,6 +323,7 @@ class GenderProximityAnalyzer:
         :param genders: a list of Gender instances.
         :param word_window: number of words to search for in either direction of a Gender instance.
         """
+        super().__init__(**kwargs)
 
         if genders is None:
             genders = BINARY_GROUP
@@ -328,25 +331,12 @@ class GenderProximityAnalyzer:
         if tags is None:
             tags = NLTK_TAGS_ADJECTIVES
 
-        if isinstance(texts, Corpus):
-            documents = texts.documents
-        elif isinstance(texts, Document):
-            documents = [texts]
-        elif isinstance(texts, list):
-            if all(isinstance(item, Document) for item in texts):
-                documents = texts
-            else:
-                raise ValueError('all items in list texts must be of type Document')
-        else:
-            raise ValueError('texts must be of type Document, Corpus, or a list of Documents')
-
         if not all(isinstance(item, str) for item in tags):
             raise ValueError('all items in list tags must be of type str')
 
         if not all(isinstance(item, Gender) for item in genders):
             raise ValueError('all items in list genders must be of type Gender')
 
-        self.documents = documents
         self.genders = genders
         self.gender_labels = [gender.label for gender in genders]
         self.tags = tags
@@ -357,7 +347,7 @@ class GenderProximityAnalyzer:
 
         results = {}
 
-        for document in self.documents:
+        for document in self.corpus:
             results[document] = _generate_gender_token_counters(document,
                                                                 genders,
                                                                 tags,
@@ -396,8 +386,7 @@ class GenderProximityAnalyzer:
                  { str(Gender.label): [(str(token), int)] }
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> corpus = Corpus(DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
-        >>> analyzer = GenderProximityAnalyzer(corpus)
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
         >>> analyzer.by_date((2000, 2008), 2).keys()
         dict_keys([2000, 2002, 2004, 2006])
         >>> analyzer.by_date((2000, 2010), 2).get(2002)
@@ -413,7 +402,7 @@ class GenderProximityAnalyzer:
         for bin_start_year in range(time_frame[0], time_frame[1], bin_size):
             output[bin_start_year] = {label: Counter() for label in self.gender_labels}
 
-        for document in self.documents:
+        for document in self.corpus:
             date = getattr(document, 'date', None)
             if date is None:
                 continue
@@ -448,11 +437,10 @@ class GenderProximityAnalyzer:
                  { str(Gender.label): [(str(token), int)] }
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> corpus = Corpus(DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
-        >>> analyzer = GenderProximityAnalyzer(corpus)
-        >>> doc = analyzer.documents[7]
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
+        >>> doc = analyzer.corpus.documents[7]
         >>> analyzer_document_labels = list(analyzer.by_document().keys())
-        >>> document_labels = list(map(lambda d: d.label, analyzer.documents))
+        >>> document_labels = list(map(lambda d: d.label, analyzer.corpus.documents))
         >>> analyzer_document_labels == document_labels
         True
         >>> analyzer.by_document().get(doc.label)
@@ -487,8 +475,7 @@ class GenderProximityAnalyzer:
 
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> corpus = Corpus(DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
-        >>> analyzer = GenderProximityAnalyzer(corpus)
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
         >>> analyzer.by_gender().keys()
         dict_keys(['Female', 'Male'])
         >>> analyzer.by_gender().get('Female')
@@ -549,8 +536,7 @@ class GenderProximityAnalyzer:
 
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> corpus = Corpus(DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
-        >>> analyzer = GenderProximityAnalyzer(corpus)
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
         >>> analyzer.by_metadata('author_gender').keys()
         dict_keys(['male', 'female'])
         >>> analyzer.by_metadata('author_gender').get('female')
@@ -594,8 +580,7 @@ class GenderProximityAnalyzer:
 
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> corpus = Corpus(DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
-        >>> analyzer = GenderProximityAnalyzer(corpus)
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
         >>> analyzer.by_overlap()
         {'sad': {'Female': 14, 'Male': 14}}
         """

--- a/gender_analysis/analysis/proximity.py
+++ b/gender_analysis/analysis/proximity.py
@@ -6,9 +6,11 @@ import nltk
 
 from gender_analysis.text.corpus import Corpus
 from gender_analysis.text.document import Document
-from gender_analysis.text.common import load_pickle, store_pickle, NLTK_TAGS, NLTK_TAGS_ADJECTIVES
+from gender_analysis.text.common import (
+    load_pickle, store_pickle, NLTK_TAGS, NLTK_TAGS_ADJECTIVES, SWORDS_ENG
+)
 
-from gender_analysis.gender.common import MALE, FEMALE, BINARY_GROUP, SWORDS_ENG
+from gender_analysis.gender.common import MALE, FEMALE, BINARY_GROUP
 from gender_analysis.gender.gender import Gender
 
 GenderTokenCounters = Dict[str, Counter]

--- a/gender_analysis/analysis/proximity.py
+++ b/gender_analysis/analysis/proximity.py
@@ -302,7 +302,7 @@ class GenderProximityAnalyzer(CorpusAnalyzer):
 
     Instance methods:
         by_date()
-        by_document(
+        by_document()
         by_gender()
         by_metadata()
         by_overlap()

--- a/gender_analysis/analysis/proximity.py
+++ b/gender_analysis/analysis/proximity.py
@@ -4,7 +4,6 @@ from functools import reduce
 from more_itertools import windowed
 import nltk
 
-from gender_analysis.text.corpus import Corpus
 from gender_analysis.text.document import Document
 from gender_analysis.text.common import (
     load_pickle, store_pickle, NLTK_TAGS, NLTK_TAGS_ADJECTIVES, SWORDS_ENG
@@ -386,7 +385,8 @@ class GenderProximityAnalyzer(CorpusAnalyzer):
                  { str(Gender.label): [(str(token), int)] }
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH,
+        ...                                    csv_path=DOCUMENT_TEST_CSV)
         >>> analyzer.by_date((2000, 2008), 2).keys()
         dict_keys([2000, 2002, 2004, 2006])
         >>> analyzer.by_date((2000, 2010), 2).get(2002)
@@ -437,7 +437,8 @@ class GenderProximityAnalyzer(CorpusAnalyzer):
                  { str(Gender.label): [(str(token), int)] }
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH,
+        ...                                    csv_path=DOCUMENT_TEST_CSV)
         >>> doc = analyzer.corpus.documents[7]
         >>> analyzer_document_labels = list(analyzer.by_document().keys())
         >>> document_labels = list(map(lambda d: d.label, analyzer.corpus.documents))
@@ -475,7 +476,8 @@ class GenderProximityAnalyzer(CorpusAnalyzer):
 
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH,
+        ...                                    csv_path=DOCUMENT_TEST_CSV)
         >>> analyzer.by_gender().keys()
         dict_keys(['Female', 'Male'])
         >>> analyzer.by_gender().get('Female')
@@ -536,7 +538,8 @@ class GenderProximityAnalyzer(CorpusAnalyzer):
 
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH,
+        ...                                    csv_path=DOCUMENT_TEST_CSV)
         >>> analyzer.by_metadata('author_gender').keys()
         dict_keys(['male', 'female'])
         >>> analyzer.by_metadata('author_gender').get('female')
@@ -580,7 +583,8 @@ class GenderProximityAnalyzer(CorpusAnalyzer):
 
         >>> from gender_analysis.testing.common import DOCUMENT_TEST_PATH, DOCUMENT_TEST_CSV
         >>> from gender_analysis import Corpus
-        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH, csv_path=DOCUMENT_TEST_CSV)
+        >>> analyzer = GenderProximityAnalyzer(file_path=DOCUMENT_TEST_PATH,
+        ...                                    csv_path=DOCUMENT_TEST_CSV)
         >>> analyzer.by_overlap()
         {'sad': {'Female': 14, 'Male': 14}}
         """

--- a/gender_analysis/analysis/text_analyzer.py
+++ b/gender_analysis/analysis/text_analyzer.py
@@ -1,0 +1,75 @@
+from typing import Optional
+from collections import Counter
+
+from ..text.corpus import Corpus
+from ..text.common import SWORDS_ENG
+
+class CorpusAnalyzer:
+    """
+    Base analyzer class for Corpus objects.
+
+    Handles initialization of Corpus and most common analysis methods.
+
+    Intended for topic-specific subclassing.
+
+    >>> from gender_analysis.analysis import CorpusAnalyzer
+    >>> from gender_analysis.testing.common import TEST_DATA_DIR
+    >>> file_path = TEST_DATA_DIR / 'document_test_files'
+    >>> metadata_csv_path = TEST_DATA_DIR / 'document_test_files' / 'document_test_files.csv'
+    >>> analyzer = CorpusAnalyzer(file_path=file_path, csv_path=metadata_csv_path)
+    >>> type(analyzer.corpus), len(analyzer.corpus)
+    (<class 'gender_analysis.text.corpus.Corpus'>, 14)
+    """
+
+    def __init__(
+        self,
+        corpus: Optional[Corpus] = None,
+        file_path: str = None,
+        csv_path: str = None,
+        name: str = None,
+        pickle_path: str = None,
+        ignore_warnings: bool = False,
+    ):
+        if corpus:
+            self.corpus = corpus
+        else:
+            if not (file_path and csv_path):
+                # TODO(ra): real exception type, better message
+                raise Exception('You must pass a file_path and csv_path')
+
+            # Create a new corpus
+            self.corpus = Corpus(
+                file_path,
+                csv_path=csv_path,
+                name=name,
+                pickle_on_load=pickle_path,
+                ignore_warnings=ignore_warnings,
+            )
+
+    def get_word_counts(self, remove_swords: bool = False) -> Counter:
+        """
+        This function returns a Counter object that stores
+        how many times each word appears in the corpus.
+
+        :return: Python Counter object
+
+        >>> from gender_analysis.analysis import CorpusAnalyzer
+        >>> from gender_analysis.testing.common import (
+        ...     TEST_CORPUS_PATH as path,
+        ...     SMALL_TEST_CORPUS_CSV as path_to_csv
+        ... )
+        >>> analyzer = CorpusAnalyzer(file_path=path, csv_path=path_to_csv, ignore_warnings=True)
+        >>> word_count = analyzer.get_word_counts()
+        >>> word_count['fire']
+        157
+
+        """
+        corpus_counter = Counter()
+        for document in self.corpus:
+            document_counter = document.get_wordcount_counter()
+            corpus_counter += document_counter
+        if remove_swords:
+            for word in list(corpus_counter):
+                if word in SWORDS_ENG:
+                    del corpus_counter[word]
+        return corpus_counter

--- a/gender_analysis/gender/common.py
+++ b/gender_analysis/gender/common.py
@@ -5,14 +5,12 @@ import zipfile
 from clint import textui
 import requests
 from nltk.parse.stanford import StanfordDependencyParser
-from nltk.corpus import stopwords
 
 from gender_analysis.common import BASE_PATH
 
 from gender_analysis.gender.pronouns import PronounSeries
 from gender_analysis.gender.gender import Gender
 
-SWORDS_ENG = stopwords.words('english')
 
 # Common Pronoun Collections
 HE_SERIES = PronounSeries('Masc', {'he', 'his', 'him', 'himself'}, subj='he', obj='him')

--- a/gender_analysis/text/common.py
+++ b/gender_analysis/text/common.py
@@ -5,9 +5,11 @@ import pickle
 from pathlib import Path
 
 import nltk
+from nltk.corpus import stopwords
 import seaborn as sns
 from chardet.universaldetector import UniversalDetector
 
+SWORDS_ENG = stopwords.words('english')
 
 NLTK_TAGS = {
     'CC': 'conjunction, coordinating',

--- a/gender_analysis/text/corpus.py
+++ b/gender_analysis/text/corpus.py
@@ -14,8 +14,8 @@ from gender_analysis.text.document import Document
 
 
 class Corpus:
-
-    """The corpus class is used to load the metadata and full
+    """
+    The corpus class is used to load the metadata and full
     texts of all documents in a corpus
 
     Once loaded, each corpus contains a list of Document objects
@@ -329,30 +329,6 @@ class Corpus:
         """
 
         return self.subcorpus('author_gender', gender)
-
-    def get_wordcount_counter(self):
-        """
-        This function returns a Counter object that stores
-        how many times each word appears in the corpus.
-
-        :return: Python Counter object
-
-        >>> from gender_analysis import Corpus
-        >>> from gender_analysis.testing.common import (
-        ...     TEST_CORPUS_PATH as path,
-        ...     SMALL_TEST_CORPUS_CSV as path_to_csv
-        ... )
-        >>> c = Corpus(path, csv_path=path_to_csv, ignore_warnings = True)
-        >>> word_count = c.get_wordcount_counter()
-        >>> word_count['fire']
-        157
-
-        """
-        corpus_counter = Counter()
-        for current_document in self.documents:
-            document_counter = current_document.get_wordcount_counter()
-            corpus_counter += document_counter
-        return corpus_counter
 
     def get_field_vals(self, field):
         """

--- a/gender_analysis/text/corpus.py
+++ b/gender_analysis/text/corpus.py
@@ -1,7 +1,6 @@
 import csv
 import random
 import os
-from collections import Counter
 from copy import deepcopy
 from pathlib import Path
 

--- a/gender_analysis/text/document.py
+++ b/gender_analysis/text/document.py
@@ -125,8 +125,7 @@ class Document:
         >>> document_string
         'austen_persuasion'
         """
-        name = self.filename[0:len(self.filename) - 4]
-        return name
+        return self.label
 
     def __repr__(self):
         '''
@@ -147,9 +146,7 @@ class Document:
         >>> repr(austen)
         '<Document (austen_persuasion)>'
         '''
-
-        name = self.filename[0:len(self.filename) - 4]
-        return f'<Document ({name})>'
+        return f'<Document ({self.label})>'
 
     def __eq__(self, other):
         """


### PR DESCRIPTION
This PR revives the work closed in https://github.com/dhmit/gender_analysis/pull/158 and is work towards creating a better, common user interface around all analytic methods in this package (https://github.com/dhmit/gender_analysis/issues/157).

Major changes:
- We implement a new base class for analysis classes: `CorpusAnalyzer`. This class manages the initialization of a Corpus and will eventually be home to the most common textual analysis methods. (n.b. the file is called `base_analyzers` to leave room for `DocumentAnalyzer` if it turns out we need that.)
- `GenderProximityAnalyzer` is refactored as a `CorpusAnalyzer` subclass. In doing so, we lose a bit of functionality—the analyzer class used to be able to take in `Union[Document, Corpus, Sequence[Document]]` for texts, but now it's less flexible. I think the right place for this flexibility is in the Corpus init, so I'll open a separate PR allowing this behavior over there.

Minor:
- Moved `SWORDS_ENG` from `gender_analysis.gender.common` to `gender_analysis.text.common`.
- There was some small work in https://github.com/dhmit/gender_analysis/pull/158 in `Document` replacing `name` with `label`, so that's here, too.